### PR TITLE
Rename branching to cloning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Version [3.3.1] - (2019-04-25)
+- Renamed `branch()` method to `clone()`. The old `branch()` method still exists to maintain backward compatibility 
+until next major release and has @Deprecated annotation. 
+
 ## Version [3.3.0] - (2019-03-04)
 - add environment branching
 

--- a/README.md
+++ b/README.md
@@ -84,13 +84,13 @@ Install the Contentful dependency:
 <dependency>
   <groupId>com.contentful.java</groupId>
   <artifactId>cma-sdk</artifactId>
-  <version>3.3.0</version>
+  <version>3.3.1</version>
 </dependency>
 ```
 
 * _Gradle_
 ```groovy
-compile 'com.contentful.java:cma-sdk:3.3.0'
+compile 'com.contentful.java:cma-sdk:3.3.1'
 ```
 
 This SDK requires Java 8 (or higher version).

--- a/src/main/java/com/contentful/java/cma/ModuleEnvironments.java
+++ b/src/main/java/com/contentful/java/cma/ModuleEnvironments.java
@@ -111,7 +111,7 @@ public final class ModuleEnvironments extends AbsModule<ServiceEnvironments> {
    * @throws IllegalArgumentException if newEnvironment is null.
    * @throws IllegalArgumentException if the space of the source environment is not set.
    */
-  public CMAEnvironment branch(CMAEnvironment sourceEnvironment, CMAEnvironment newEnvironment) {
+  public CMAEnvironment clone(CMAEnvironment sourceEnvironment, CMAEnvironment newEnvironment) {
     assertNotNull(sourceEnvironment, "sourceEnvironment");
     assertNotNull(newEnvironment, "newEnvironment");
     assertNotNull(sourceEnvironment.getSpaceId(), "sourceEnvironment.spaceId");
@@ -123,14 +123,34 @@ public final class ModuleEnvironments extends AbsModule<ServiceEnvironments> {
 
     try {
       if (environmentId == null) {
-        return service.branch(spaceId, sourceEnvironment.getId(), newEnvironment).blockingFirst();
+        return service.clone(spaceId, sourceEnvironment.getId(), newEnvironment).blockingFirst();
       } else {
-        return service.branch(spaceId, sourceEnvironment.getId(), environmentId, newEnvironment)
+        return service.clone(spaceId, sourceEnvironment.getId(), environmentId, newEnvironment)
             .blockingFirst();
       }
     } finally {
       newEnvironment.setSystem(system);
     }
+  }
+
+  /**
+   * Create an environment based on the content of another environment.
+   * <p>
+   * This method will override the configuration specified through
+   * {@link CMAClient.Builder#setSpaceId(String)}.
+   *
+   * @param sourceEnvironment the environment to be taken as a source of branching
+   * @param newEnvironment    the environment to be created, based on the source.
+   * @return {@link CMAEnvironment} result instance
+   * @throws IllegalArgumentException if sourceEnvironment is null.
+   * @throws IllegalArgumentException if newEnvironment is null.
+   * @throws IllegalArgumentException if the space of the source environment is not set.
+   * @deprecated This method has been renamed to {@link #clone(CMAEnvironment, CMAEnvironment)}.
+   * It will be removed in the next major release.
+   */
+  @Deprecated
+  public CMAEnvironment branch(CMAEnvironment sourceEnvironment, CMAEnvironment newEnvironment) {
+    return this.clone(sourceEnvironment, newEnvironment);
   }
 
   /**
@@ -314,16 +334,38 @@ public final class ModuleEnvironments extends AbsModule<ServiceEnvironments> {
      * @throws IllegalArgumentException if space id is null.
      * @throws IllegalArgumentException if environment is null.
      */
-    public CMACallback<CMAEnvironment> branch(
+    public CMACallback<CMAEnvironment> clone(
         final CMAEnvironment sourceEnvironment,
         final CMAEnvironment newEnvironment,
         CMACallback<CMAEnvironment> callback) {
       return defer(new DefFunc<CMAEnvironment>() {
         @Override
         CMAEnvironment method() {
-          return ModuleEnvironments.this.branch(sourceEnvironment, newEnvironment);
+          return ModuleEnvironments.this.clone(sourceEnvironment, newEnvironment);
         }
       }, callback);
+    }
+
+    /**
+     * Create an environment using a source environment.
+     * <p>
+     * This method will override the configuration specified through
+     * {@link CMAClient.Builder#setSpaceId(String)}.
+     *
+     * @param sourceEnvironment base of the created environment.
+     * @param newEnvironment    to be created environment.
+     * @param callback          Callback
+     * @return the given CMACallback instance
+     * @throws IllegalArgumentException if space id is null.
+     * @throws IllegalArgumentException if environment is null.
+     * @deprecated This method has been renamed to {@link #clone(CMAEnvironment, CMAEnvironment)}.
+     * It will be removed in the next major release.
+     */
+    public CMACallback<CMAEnvironment> branch(
+        final CMAEnvironment sourceEnvironment,
+        final CMAEnvironment newEnvironment,
+        CMACallback<CMAEnvironment> callback) {
+      return this.clone(sourceEnvironment, newEnvironment, callback);
     }
 
     /**

--- a/src/main/java/com/contentful/java/cma/ServiceEnvironments.java
+++ b/src/main/java/com/contentful/java/cma/ServiceEnvironments.java
@@ -38,7 +38,7 @@ interface ServiceEnvironments {
       @Body CMAEnvironment environment);
 
   @POST("/spaces/{spaceId}/environments")
-  Flowable<CMAEnvironment> branch(
+  Flowable<CMAEnvironment> clone(
       @Path("spaceId") String spaceId,
       @Header("X-Contentful-Source-Environment") String sourceEnvironmentId,
       @Body CMAEnvironment environment);
@@ -50,7 +50,7 @@ interface ServiceEnvironments {
       @Body CMAEnvironment environment);
 
   @PUT("/spaces/{spaceId}/environments/{environmentId}")
-  Flowable<CMAEnvironment> branch(
+  Flowable<CMAEnvironment> clone(
       @Path("spaceId") String spaceId,
       @Header("X-Contentful-Source-Environment") String sourceEnvironmentId,
       @Path("environmentId") String environmentId,

--- a/src/test/bash/environments_create_from_id.sh
+++ b/src/test/bash/environments_create_from_id.sh
@@ -7,8 +7,8 @@ curl --verbose \
     -H 'Content-Type: application/vnd.contentful.management.v1+json' \
     -H 'Authorization: Bearer '$CMA_TOKEN  \
     -H 'X-Contentful-Source-Environment: io'  \
-    -d '{"name":"environment branched from io"}' \
-    "https://api.contentful.com/spaces/$SPACE_ID/environments/branched_from_io" \
+    -d '{"name":"environment cloned from io"}' \
+    "https://api.contentful.com/spaces/$SPACE_ID/environments/cloned_from_io" \
     | sed 's/'${SPACE_ID}'/<space_id>/g' \
     | sed 's/'${CMA_TOKEN}'/<access_token>/g' \
     | sed 's/'${USER_ID}'/<user_id>/g' \

--- a/src/test/kotlin/com/contentful/java/cma/EnvironmentsTests.kt
+++ b/src/test/kotlin/com/contentful/java/cma/EnvironmentsTests.kt
@@ -152,20 +152,20 @@ class EnvironmentsTests {
 
         val newEnvironment = CMAEnvironment().apply {
             name = "environment_from_id"
-            id = "branched_from_io"
+            id = "cloned_from_io"
         }
 
         val result = assertTestCallback(
                 client!!
                         .environments()
                         .async()
-                        .branch(
+                        .clone(
                                 sourceEnvironment,
                                 newEnvironment,
                                 TestCallback()
                         ) as TestCallback)!!
 
-        assertEquals("branched_from_io", result.id)
+        assertEquals("cloned_from_io", result.id)
         assertEquals("<space_id>", result.spaceId)
 
         // Request
@@ -173,7 +173,7 @@ class EnvironmentsTests {
         assertEquals("PUT", recordedRequest.method)
         assertTrue(recordedRequest.headers.names().contains("X-Contentful-Source-Environment"))
         assertEquals("source", recordedRequest.headers["X-Contentful-Source-Environment"])
-        assertEquals("/spaces/configuredSpaceId/environments/branched_from_io", recordedRequest.path)
+        assertEquals("/spaces/configuredSpaceId/environments/cloned_from_io", recordedRequest.path)
     }
 
     @test
@@ -197,13 +197,13 @@ class EnvironmentsTests {
                 client!!
                         .environments()
                         .async()
-                        .branch(
+                        .clone(
                                 sourceEnvironment,
                                 newEnvironment,
                                 TestCallback()
                         ) as TestCallback)!!
 
-        assertEquals("branched_from_io", result.id)
+        assertEquals("cloned_from_io", result.id)
         assertEquals("<space_id>", result.spaceId)
 
         // Request

--- a/src/test/kotlin/com/contentful/java/cma/e2e/EnvironmentsE2E.kt
+++ b/src/test/kotlin/com/contentful/java/cma/e2e/EnvironmentsE2E.kt
@@ -43,18 +43,18 @@ class EnvironmentsE2E {
     }
 
     @Test
-    fun testBranchingOfEnvironments() {
+    fun testCloningOfEnvironments() {
         var created: CMAEnvironment? = null
         try {
             val sourceEnvironment = client.environments().fetchOne(SPACE_ID, "empty")
-            val newEnvironment = CMAEnvironment().setName("branched_from_empty")
+            val newEnvironment = CMAEnvironment().setName("cloned_from_empty")
 
-            created = client.environments().branch(sourceEnvironment, newEnvironment)
+            created = client.environments().clone(sourceEnvironment, newEnvironment)
             while (created!!.status != CMAEnvironmentStatus.Ready) {
                 created = client.environments().fetchOne(created.id)
             }
 
-            assertEquals("branched_from_empty", created.name)
+            assertEquals("cloned_from_empty", created.name)
             assertEquals(numberOfEntriesOnEnvironment("empty"), numberOfEntriesOnEnvironment(created.id))
         } finally {
             if (created != null) {

--- a/src/test/resources/environments_create_from_id.json
+++ b/src/test/resources/environments_create_from_id.json
@@ -1,8 +1,8 @@
 {
-  "name":"environment branched from io",
+  "name":"environment cloned from io",
   "sys":{
     "type":"Environment",
-    "id":"branched_from_io",
+    "id":"cloned_from_io",
     "version":1,
     "space":{
       "sys":{


### PR DESCRIPTION
- As the Java SDK is the only SDK that implements a branch method we should rename the function to be aligned with the feature name "cloning".
- As this is a breaking change we should first deprecate the function and remove it in the next major release.

ACs
 *   create a clone method with current implementation of branch method
 *   current branch method uses clone method
 *   current branch method should have a @deprecated annotation, telling users to use clone (generates a compile time warning)
 *   add deprecation note to README/CHANGELOG/javadoc and other release notes.
